### PR TITLE
add pharo8.x to baseline spec

### DIFF
--- a/BaselineOfSmalltalkVimMode.package/BaselineOfSmalltalkVimMode.class/instance/baseline..st
+++ b/BaselineOfSmalltalkVimMode.package/BaselineOfSmalltalkVimMode.class/instance/baseline..st
@@ -3,7 +3,7 @@ baseline: spec
   <baseline>
 
  spec
-  for: #('pharo6.x' 'pharo7.x')
+  for: #('pharo6.x' 'pharo7.x' 'pharo8.x')
   do: [ 
 	  spec package: 'SmalltalkVimMode'.
    spec group: 'default' with: #('SmalltalkVimMode') ]


### PR DESCRIPTION
Enables SmalltalkVimMode to work in Pharo 8.0